### PR TITLE
fix: resolve issue with linking semantic color to primitive after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ThMLT Chrome Extension (v1.0.1)
+# ThMLT Chrome Extension (v1.0.2)
 
 This project is a Chrome extension designed to manage and manipulate themes, colors, and filter specific layouts for [ThMLT AI2 Extension](https://github.com/hridoy/ThMLT_ChromeExtension). The chrome extension provides various functionalities including importing/exporting JSON data, managing projects, and filtering layout components.
 

--- a/colorsScreenScript.js
+++ b/colorsScreenScript.js
@@ -872,10 +872,13 @@
 
       const parentTd = target.closest('td');
       const dataIndex = parentTd ? parentTd.getAttribute('data-index') : null;
-      const semanticName = CacheOperations.getAllSemanticNames()[dataIndex - 1];
+      const semanticName = parentTd ? parentTd.closest('tr').querySelector('.semantic-name').textContent.trim() : null;
       const themeMode = parentTd ? parentTd.getAttribute('theme-mode') : null;
-
-      ShowSelectPrimitiveModal(dataIndex, themeMode, semanticName);
+      if (dataIndex && semanticName && themeMode) {
+        ShowSelectPrimitiveModal(dataIndex, themeMode, semanticName);
+      } else {
+        AlertManager.error("Internal error", 1000);
+      }
     } else if (target.tagName === "TD" && target.getAttribute("theme-mode")) {
 
       const isDefaultTheme = target.getAttribute("default-theme-header");


### PR DESCRIPTION
Fixes the issue where a semantic color cannot be linked to a primitive color immediately after creation. The error "Semantic color 'undefined' for theme 'Light' not found" was thrown during the linking process. This fix ensures proper synchronization, allowing semantic colors to be linked to primitives without restarting the program.